### PR TITLE
Added tab to delimeters for gnu make

### DIFF
--- a/gnumake.uew
+++ b/gnumake.uew
@@ -1,5 +1,5 @@
 /L10"Makefiles" Line Comment = # String Chars = "' File Extensions = MAK MK
-/Delimiters = ~!&+=|\/{}[];"'()> ,
+/Delimiters = ~!&+=|\/{}[];"'()>	 ,
 /Marker Characters = "()"
 /C1"Variables"
 $% $* $< $? $@ $^


### PR DESCRIPTION
I noticed that the tab character was not present in the gnu make wordfile. This was causing in-line comments separated by a tab to not be highlighted as comments.

Here's an example of the code that was causing highlight issues

`Line_1_with_tab	# Comment`

`Line_2_with_spaces    # Comment`