### PR TITLE
Added CSS_LANG flag

### DIFF
--- a/scss.uew
+++ b/scss.uew
@@ -1,4 +1,4 @@
-/L20"SCSS" Nocase Line Comment = // Block Comment On = /* Block Comment Off = */ String Chars = "' Escape Char = \ DisableMLS File Extensions = SCSS
+/L20"SCSS" CSS_LANG Nocase Line Comment = // Block Comment On = /* Block Comment Off = */ String Chars = "' Escape Char = \ DisableMLS File Extensions = SCSS
 /TGBegin "Imports"
 /TGFindStr = "@import(?:\s+url)?[\s\("']+([a-z/\.\-]*?)[\)"']+"
 /TGEnd


### PR DESCRIPTION
CSS_LANG flag should be included for SASS files as they are basically extended CSS.  Needed for things like color picker on-hover functionality, etc.